### PR TITLE
fixed typo option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you want to stop publishing outside Kubernetes, please delete the auto-genera
 You deploy manifests for Longhorn external manager.
 
 ```
-$ kubectl apply -k manifests/
+$ kubectl apply -f manifests/
 ```
 
 :memo:


### PR DESCRIPTION
Fixed typo of kubectl option in README